### PR TITLE
feat: Implement HTTP-only cookies for JWT token storage

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -42,6 +42,15 @@ const registerUser = asyncHandler( async (req,res) => {
 
    // Generate Token
    const token = generateToken(user._id)
+
+   // Send HTTP-only cookie
+   res.cookie('token', token, {
+    path: '/',
+    httpOnly: true,
+    expires:  new Date(Date.now() + 1000 * 86400), // Expires in 1 day
+    sameSite: 'none',
+    secure: true,
+   })
    
    if (user) {
     console.log('User Created!')

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.2",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.4.2",
         "express": "^4.18.2",
@@ -235,6 +236,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.2",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.4.2",
     "express": "^4.18.2",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const express = require("express")
 const mongoose = require("mongoose")
 const bodyParser = require("body-parser")
 const cors = require("cors")
+const cookieParser = require("cookie-parser")
 
 
 const userRoutes = require('./backend/routes/userRoute') 
@@ -12,6 +13,7 @@ const app = express()
 
 // Middleware
 app.use(express.json())
+app.use(cookieParser())
 app.use(express.urlencoded({extended: false}))
 app.use(bodyParser.json())
 


### PR DESCRIPTION
## Description ##
This commit implements the use of HTTP-only cookies for JWT token storage. Upon successful user registration, a JWT token is now stored as an HTTP-only cookie, enhancing security by preventing client-side JavaScript from accessing it.

## Changes Implemented ##
- Modified UserController.js to send the JWT token as an HTTP-only cookie.
- Added "cookie-parser" package to the dependencies in Packages.json.
- Integrated cookie parsing middleware in Server.js to parse incoming cookies.

## Testing ##
- Manually tested cookie functionality by registering new users and verifying the presence of the JWT token cookie in the browser's cookie storage.

## Token Received ##
<img width="1198" alt="Token Received" src="https://github.com/WilliamPasternak/Inventory-App/assets/31456405/7c36e322-f568-48a8-8b64-66da9b1d69ec">


## Token as Cookie ##
<img width="1156" alt="Token as cookie" src="https://github.com/WilliamPasternak/Inventory-App/assets/31456405/d67aa930-0377-424a-9543-c8276b9c7c74">

