### PR TITLE
feat: Add user profile route and protect middleware

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -128,9 +128,25 @@ const logout = asyncHandler(async (req, res) => {
       })
 })
 
+// Get User Profile
+const getUser = asyncHandler(async (req,res) => {
+    
+    const user = await User.findById(req.user._id)
+    
+    if (user) {
+        const {_id, name, photo, role} = user
+        res.status(200).json({
+            _id, name, photo, role
+        })
+       } else {
+        res.status(400)
+        throw new Error('User not found.')
+       }
+})
 
 module.exports = {
     registerUser,
     loginUser,
-    logout
+    logout,
+    getUser,
 }

--- a/backend/middleWare/authMiddleware.js
+++ b/backend/middleWare/authMiddleware.js
@@ -1,0 +1,30 @@
+const asyncHandler = require("express-async-handler");
+const User = require("../models/User");
+const jwt = require("jsonwebtoken");
+
+const protect = asyncHandler(async (req, res, next) => {
+  try {
+    const token = req.cookies.token;
+    if (!token) {
+      res.status(401);
+      throw new Error("Not authorized, please login");
+    }
+
+    // Verify Token
+    const verified = jwt.verify(token, process.env.JWT_SECRET);
+    // Get user id from token
+    const user = await User.findById(verified.id).select("-password");
+
+    if (!user) {
+      res.status(401);
+      throw new Error("User not found");
+    }
+    req.user = user;
+    next();
+  } catch (error) {
+    res.status(401);
+    throw new Error("Not authorized, please login");
+  }
+});
+
+module.exports = protect;

--- a/backend/routes/userRoute.js
+++ b/backend/routes/userRoute.js
@@ -1,10 +1,12 @@
 const express = require("express")
 const router = express.Router()
-const { registerUser, loginUser, logout} = require("../controllers/userController")
+const { registerUser, loginUser, logout, getUser} = require("../controllers/userController")
+const protect = require("../middleWare/authMiddleware")
 
 router.post('/register', registerUser)
 router.post('/login', loginUser)
 router.get('/logout', logout)
+router.get('/getuser', protect, getUser)
 
 
 module.exports = router

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,14 +167,15 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.6.tgz",
-      "integrity": "sha512-Mj50FLHtlsoVfRfnHaZvyrooHcrlceNZdL/QBvJJVd9Ta55qCQK0gs4ss2oZDeV9zFCs6ewzYgVE5yfVmfFpVg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.3",
-        "set-function-length": "^1.2.0"
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -233,9 +234,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -250,14 +251,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/cookie-parser/node_modules/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
@@ -286,17 +279,19 @@
       }
     },
     "node_modules/define-data-property": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.2.tgz",
-      "integrity": "sha512-SRtsSqsDbgpJBbW3pABMCOt6rQyeM8s8RiyeSN8jYG8sYmt/kGJejbydttUsnDs1tadr19tvhT4ShwMyoqAm4g==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dependencies": {
+        "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.2",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.1"
+        "gopd": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/depd": {
@@ -346,6 +341,17 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-errors": {
@@ -436,6 +442,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/raw-body": {
@@ -570,11 +584,11 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
-      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
-        "get-intrinsic": "^1.2.2"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -603,9 +617,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.1.tgz",
+      "integrity": "sha512-1/th4MHjnwncwXsIW6QMzlvYL9kG5e/CpVvLRZe4XPa8TOUNbCELqmvhDmnkNsAjwaG4+I8gJJL0JBvTTLO9qA==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -922,9 +936,9 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.1.1.tgz",
-      "integrity": "sha512-DbLb0NsiEXmaqLOpEz+AtAsgwhRw6f25gwa1dF5R7jj6lS1D8X6uTdhBSC8GDVtOwe5Tfw2EL7nTn6hiJT3Bgg==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.1.3.tgz",
+      "integrity": "sha512-a5MajZSDJiQgy0iQcR+MIpFe7zehGJI4doJ6Dh1MvnGh8/HNNhr5pn07RPA86KCTjP2vuKdffpFmvXxcHiUOjw==",
       "dependencies": {
         "bson": "^6.2.0",
         "kareem": "2.5.1",


### PR DESCRIPTION
## Pull Request: Implement User Profile Route and Protect Middleware

### Description
This pull request adds functionality to retrieve user profile information via a new route `/api/users/getuser`. It also introduces a protect middleware to ensure that only authenticated users can access certain routes.

### Changes Made
- Added a new route `/api/users/getuser` to retrieve user profile information.
- Implemented protect middleware to authenticate and authorize access to protected routes.

### Testing
- Tested the user profile route with and without authentication using Postman.
- Verified that only authenticated users can access protected routes.

### Logged In User
A logged in user can retrieve profile information
<img width="1209" alt="loggedIn" src="https://github.com/WilliamPasternak/count/assets/31456405/d24e5ff4-13e7-4e39-a07f-349684113282">

### User Not Logged In
A user who is logged out is blocked from retrieving profile information from Protect middleware.
<img width="1207" alt="notLoggedIn" src="https://github.com/WilliamPasternak/count/assets/31456405/7957a6dd-303c-46cd-952c-c968e7e14874">


